### PR TITLE
fix: capturing wrong references to loop variables from a goroutine

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -95,6 +95,7 @@ func (ih *Inhibitor) Run() {
 	runCtx, runCancel := context.WithCancel(ctx)
 
 	for _, rule := range ih.rules {
+		rule := rule
 		go rule.scache.Run(runCtx, 15*time.Minute)
 	}
 


### PR DESCRIPTION
In file: inhibit.go, there is a function Run which has a goroutine running inside a loop while using the iteration variable of the enclosing loop. This may lead to a scenario in which the inner function may observe the wrong value of the iteration variable coming from a different iteration and may lead to a race condition. This scenario is likely to happen with go version 1.21 and prior to that.

##### Fix
according to [documentation](https://go.dev/doc/faq#closures_and_goroutines) one of the fix
> is just to create a new variable, using a declaration style

```go
for _, rule := range ih.rules {
	rule := rule
	go rule.scache.Run(runCtx, 15*time.Minute)
}
```
from [go.mod](https://github.com/databricks/alertmanager/blob/main/go.mod) file
```
module github.com/prometheus/alertmanager

go 1.21
```

so, this type of race condition problem is likely to happen with this go version

##### Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.